### PR TITLE
prevent empty todo items from being entered, display error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from "react";
 import { useAuth } from "oidc-react";
-import { Todos } from "./components/Todos";
+import React, { useCallback, useEffect, useState } from "react";
 import { ToastContainer, toast } from "react-toastify";
+import { Todos } from "./components/Todos";
 import { AppProps, Todo, User } from "./interfaces";
 import { useTodoService, useUser } from "./todoService";
 
@@ -37,6 +37,11 @@ export const App: React.FC<AppProps> = (props) => {
   const handleSubmit: () => void = async () => {
     if (userEmail === "" || typeof userEmail === "undefined") {
       errorHandler("No user email found.");
+      return;
+    }
+
+    if (todoTitle === "") {
+      errorHandler("No Todo item entered.");
       return;
     }
 


### PR DESCRIPTION
we allow empty todo items to be placed in the list. this PR prevents this and displays an error

<img width="529" alt="image" src="https://github.com/aserto-demo/todo-application/assets/11022003/7e41dd3e-4859-4e14-a201-089da5f2b411">


## Test plan

Press _enter_ without typing anything in the input. No empty todo item should show up in the list, and you should see this error : `No Todo item entered.`

<img width="367" alt="image" src="https://github.com/aserto-demo/todo-application/assets/11022003/55a7629e-1a81-4b09-98e9-a34a5a5703a1">
